### PR TITLE
Attempt to fix windows file save

### DIFF
--- a/cmd/instacart-export/main.go
+++ b/cmd/instacart-export/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"log"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -68,7 +69,8 @@ func writeToCSV(data [][]string) {
 	log.Print("Writing orders to a CSV")
 
 	now := time.Now()
-	file, err := os.Create("data/instacart_orders_" + now.Format("01-02-2006_03-04-05") + ".csv")
+	p = filepath.Join("data", "instacart_orders_" + now.Format("01-02-2006_03-04-05") + ".csv")
+	file, err := os.Create(p)
 	if err != nil {
 		log.Fatal("Unable to create file", err)
 	}

--- a/cmd/instacart-export/main.go
+++ b/cmd/instacart-export/main.go
@@ -69,7 +69,7 @@ func writeToCSV(data [][]string) {
 	log.Print("Writing orders to a CSV")
 
 	now := time.Now()
-	p = filepath.Join("data", "instacart_orders_" + now.Format("01-02-2006_03-04-05") + ".csv")
+	p := filepath.Join("data", "instacart_orders_" + now.Format("01-02-2006_03-04-05") + ".csv")
 	file, err := os.Create(p)
 	if err != nil {
 		log.Fatal("Unable to create file", err)


### PR DESCRIPTION
Switched to using filepath.Join for OS-agnostic implementation of saving the data at the end of the run.

Makes it so windowsy users can use it, one hopes.